### PR TITLE
Made chevrons to always toggle when they're clicked.

### DIFF
--- a/lib/chary-tree-view.js
+++ b/lib/chary-tree-view.js
@@ -10,26 +10,46 @@ module.exports = {
 
         treeView.oldEntryClicked = treeView.entryClicked;
 
-        const isDirectoryElements = element =>
+        const isDirectoryElement = element =>
           element.classList.contains('directory') ||
           element.parentNode.classList.contains('directory') ||
           element.parentNode.parentNode &&
           element.parentNode.parentNode.classList.contains('directory');
 
-        const isOneOfThoseElements = element =>
-          (element.classList.contains('entry') ||
-          element.parentNode.classList.contains('entry') ||
-          element.parentNode.parentNode &&
-          element.parentNode.parentNode.classList.contains('entry')) &&
-          (!atom.config.get('chary-tree-view.dirSingleClick') ||
-            !isDirectoryElements(element));
+          const shouldToggleOnDblClick = (e) =>
+          {
+            if (e.target.classList.contains('entry') ||
+              e.target.parentNode.classList.contains('entry') ||
+              e.target.parentNode.parentNode &&
+              e.target.parentNode.parentNode.classList.contains('entry'))
+            {
+              if (isDirectoryElement(e.target))
+              {
+                // If directory single click is on, then just toggle.
+                if (atom.config.get('chary-tree-view.dirSingleClick'))
+                  return false;
+                else if (e.target.classList.contains('header'))
+                {
+                  // Find the name span so we can compare the click position with it.
+                  let span = e.target.querySelector(':scope > .name');
+
+                  if (e.offsetX < span.offsetLeft)
+                    return false;
+                }
+              }
+
+              return true;
+            }
+
+            return false;
+          }
 
         treeView.entryClicked = e =>
-          !isOneOfThoseElements(e.target) &&
+          !shouldToggleOnDblClick(e) &&
           treeView.oldEntryClicked.call(treeView, e);
 
         dblClickHandler = e =>
-          isOneOfThoseElements(e.target) &&
+          shouldToggleOnDblClick(e) &&
           treeView.oldEntryClicked.call(treeView, e);
 
         treeView.element.addEventListener('dblclick', dblClickHandler)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chary-tree-view",
   "main": "./lib/chary-tree-view",
-  "version": "0.2.11",
+  "version": "0.3.0",
   "description": "Tree-view responds to only double-click to avoid opening a large file accidentally",
   "keywords": [
     "tree-view",


### PR DESCRIPTION
Hey guys,

Like the title says, it makes the chevrons next to directory entries single clickable, regardless of the setting.

I also took the liberty to rename those two functions a bit:

isDirectoryElements => isDirectoryElement
isOneOfThoseElements => shouldToggleOnDblClick

Best Regards